### PR TITLE
Feat/skip-step-3 157

### DIFF
--- a/frontend/app/components/import_process/fields-mapping-step/fields-mapping-step.component.html
+++ b/frontend/app/components/import_process/fields-mapping-step/fields-mapping-step.component.html
@@ -362,3 +362,34 @@
         > OK </button>
     </div>
 </ng-template>
+
+<ng-template
+    #modalNoNomenc
+    let-modal
+>
+    <div class="modal-header">
+        <h4
+            class="modal-title"
+            id="modal-basic-title"
+        >Aucune nomenclature n'a pu être mappée</h4>
+        <button
+            type="button"
+            class="close"
+            aria-label="Close"
+            (click)="modal.dismiss('Cross click')"
+        >
+            <span aria-hidden="true">&times;</span>
+        </button>
+    </div>
+    <div class="modal-body">
+        Puisqu'aucune correspondance de nomenclature n'a pu
+        être trouvée, l'étape 3 a été passée.
+    </div>
+    <div class="modal-footer">
+        <button
+            type="button"
+            class="btn btn-info"
+            (click)="modal.dismiss('Cross click')"
+        > OK </button>
+    </div>
+</ng-template>

--- a/frontend/app/components/import_process/fields-mapping-step/fields-mapping-step.component.ts
+++ b/frontend/app/components/import_process/fields-mapping-step/fields-mapping-step.component.ts
@@ -58,6 +58,7 @@ export class FieldsMappingStepComponent implements OnInit {
   public nbLignes: number;
   @ViewChild("modalConfirm") modalConfirm: any;
   @ViewChild("modalRedir") modalRedir: any;
+  @ViewChild("modalNoNomenc") modalNoNomenc: any;
   constructor(
     private _ds: DataService,
     private _fm: FieldMappingService,
@@ -243,6 +244,7 @@ export class FieldsMappingStepComponent implements OnInit {
     this.stepService.setStepData(2, step2data);
 
     const mappingData = Object.assign({}, this.syntheseForm.value);
+    
     this._ds
       .createOrUpdateFieldMapping(mappingData, this.id_mapping)
       .subscribe(data => {
@@ -263,8 +265,13 @@ export class FieldsMappingStepComponent implements OnInit {
           .subscribe(d => {
             console.log("Done");
           });
-
-        if (!ModuleConfig.ALLOW_VALUE_MAPPING) {
+        
+        // Check if there are nomenclature that are mapped
+        const hasNomencValues = this.checkHasNomencValues(mappingData)
+        // const hasNomencValues = this.checkHasNomencValues(
+        //                       this.stepData.importId, this.id_mapping)
+            
+        if (!ModuleConfig.ALLOW_VALUE_MAPPING || !hasNomencValues) {
           this._ds
             .dataChecker(
               this.stepData.importId,
@@ -278,11 +285,16 @@ export class FieldsMappingStepComponent implements OnInit {
                   importId: this.stepData.importId
                 };
                 if (import_obj.source_count < ModuleConfig.MAX_LINE_LIMIT) {
+                  // Show an info modal if no nomenclature has been mapped
+                  if (!hasNomencValues) {
+                    this._modalService.open(this.modalNoNomenc);
+                  }
                   this.stepService.setStepData(4, step4Data);
                   this._router.navigate([
                     `${ModuleConfig.MODULE_URL}/process/id_import/${import_obj.id_import}/step/4`
                   ]);
-                } else {
+                } 
+                else {
                   this.nbLignes = import_obj.source_count;
                   this._modalService.open(this.modalRedir);
                 }
@@ -295,10 +307,18 @@ export class FieldsMappingStepComponent implements OnInit {
                 );
               }
             );
-        } else {
+        } 
+        else {
           this._router.navigate([`${ModuleConfig.MODULE_URL}/process/id_import/${this.stepData.importId}/step/3`]);
         }
       });
+  }
+
+  checkHasNomencValues(mappingData) {
+    // TODO: make the startsWith check more robust
+    return Object.keys(mappingData)
+            .filter(key => key.startsWith('id_nomenclature'))
+            .reduce((_, key) => mappingData[key] != "", {})
   }
 
   // On close modal: ask if save the mapping or not

--- a/frontend/app/components/import_process/fields-mapping-step/fields-mapping-step.component.ts
+++ b/frontend/app/components/import_process/fields-mapping-step/fields-mapping-step.component.ts
@@ -320,7 +320,8 @@ export class FieldsMappingStepComponent implements OnInit {
                              idFieldMapping: number): Promise<boolean> {
     // checks by an API call that there is nomenclature mapped.
     // Returns a promise than must be awaited
-    const data = await this._ds.getNomencSynchronous(idImport, idFieldMapping);
+    const data = await this._ds.getNomencInfoSynchronous(idImport, 
+                                                         idFieldMapping);
     return data.content_mapping_info.length > 0
   }
 

--- a/frontend/app/services/data.service.ts
+++ b/frontend/app/services/data.service.ts
@@ -177,7 +177,7 @@ export class DataService {
   }
 
   getNomencInfoSynchronous(id_import: number, 
-                           id_field_mapping: number): Promise<Object> {
+                           id_field_mapping: number): Promise<{content_mapping_info: Array<Object>}> {
     // Same as NomencInfo but returns the Promise
     return this.getNomencInfo(id_import, id_field_mapping).toPromise();
   }

--- a/frontend/app/services/data.service.ts
+++ b/frontend/app/services/data.service.ts
@@ -176,6 +176,10 @@ export class DataService {
     );
   }
 
+  getNomencSynchronous(id_import, id_field_mapping) {
+    return this.getNomencInfo(id_import, id_field_mapping).toPromise();
+  }
+
   importData(import_id) {
     return this._http.get<any>(`${urlApi}/importData/${import_id}`);
   }

--- a/frontend/app/services/data.service.ts
+++ b/frontend/app/services/data.service.ts
@@ -176,7 +176,9 @@ export class DataService {
     );
   }
 
-  getNomencSynchronous(id_import, id_field_mapping) {
+  getNomencInfoSynchronous(id_import: number, 
+                           id_field_mapping: number): Promise<Object> {
+    // Same as NomencInfo but returns the Promise
     return this.getNomencInfo(id_import, id_field_mapping).toPromise();
   }
 


### PR DESCRIPTION
## Objectif
Vérifier au passage à l'étape 3 s'il y a des correspondances dans les nomenclatures. Si ce n'est pas le cas, passer l'étape 3.

## Implémentation
Un appel synchrone à l'API (`getNomencInfo`) de l'import est fait depuis le frontend. Cela renvoie un objet `content_mapping_info` contenant les mappings des nomenclatures. S'il est vide alors on passe à l'étape 4 directement en affichant le dialogue suivant : 
![skip_step_screenshot](https://user-images.githubusercontent.com/85738261/131625028-f72fa9ff-d627-495c-94bf-b98a514a6336.png)


Closes #157 
