### PR TITLE
Feat/import model 146

### DIFF
--- a/frontend/app/components/import_process/fields-mapping-step/fields-mapping-step.component.html
+++ b/frontend/app/components/import_process/fields-mapping-step/fields-mapping-step.component.html
@@ -53,6 +53,22 @@
                             >
                                 Modifier le nom du modèle d'import
                             </button>
+                            <button
+                                *ngIf="cruvedStore?.cruved?.IMPORT.module_objects.MAPPING.cruved.C != '0'"
+                                class="mb-3 ml-1"
+                                mat-raised-button
+                                color="primary"
+                                (click)="fileInput.click()"
+                            >
+                                Charger un modèle d'import
+                            </button>
+                            <input 
+                                hidden 
+                                (change)="onFileProvided($event)" 
+                                #fileInput 
+                                type="file"
+                                accept=".json" 
+                                id="file">
                         </div>
 
 

--- a/frontend/app/components/import_process/fields-mapping-step/fields-mapping-step.component.ts
+++ b/frontend/app/components/import_process/fields-mapping-step/fields-mapping-step.component.ts
@@ -537,7 +537,10 @@ export class FieldsMappingStepComponent implements OnInit {
         this.loadMapping(JSON.parse(result))
         };
       reader.onerror = (error: any) => {
-        console.log(error)
+        this._commonService.regularToaster(
+          "error",
+          `ERROR: ${error}`
+        );
       }
 
       // Calls onload handler
@@ -546,7 +549,12 @@ export class FieldsMappingStepComponent implements OnInit {
     }
 
   loadMapping(data) {
+    // Reset mapping
+    this.fillEmptyMapping(this.syntheseForm);
+    // Fill mapping from data 
+    // (array of object with target_field and source_field)
     this.fillFormFromMappings(data)
+    // If no mapping had been done
     if (this.mappedList.length == 0) {
       this._commonService.regularToaster(
         "error",


### PR DESCRIPTION
## Objectif
 - [x] Permettre de charger à l'étape 2 un fichier JSON contenant les correspondances des champs
 - [ ] Permettre de charger à l'étape 3 un fichier JSON contenant les correspondances des nomenclatures

Ces fichiers peuvent être crées à la main ou exportés depuis le rapport d'import (voir #158). Exemple d'un fichier :
```javascript
[
    {
        "source_field": "true",
        "target_field": "unique_id_sinp_generate"
    },
    {
        "source_field": "dateobs",
        "target_field": "date_min"
    },
    {
        "source_field": "true",
        "target_field": "altitudes_generate"
    }
]
```

## Implémentation
Première implémentation : chargement depuis le front d'un fichier json et remplacement direct des champs par son contenu.
Si aucun champ n'a été mappé une erreur (via un toaster) est affichée.

Closes #146 