### PR TITLE
Feat/remove model

### DIFF
--- a/backend/db/repositories.py
+++ b/backend/db/repositories.py
@@ -81,10 +81,19 @@ class TMappingsRepository:
                 object_code="MAPPING",
             )[0]
             mapping_as_dict = []
+
+            user_owned_mappings_res = (
+                        DB.session.query(CorRoleMapping.id_mapping)
+                        .filter(CorRoleMapping.id_role == info_role.id_role)
+                        .all()
+                    )
+            user_owned_mappings = [t.id_mapping for t in
+                                   user_owned_mappings_res]
+
             for d in data:
                 temp = d.as_dict()
                 temp["cruved"] = self.get_mapping_cruved(
-                    user_cruved, d.id_mapping, users_mapping
+                    user_cruved, d.id_mapping, user_owned_mappings
                 )
                 mapping_as_dict.append(temp)
             return mapping_as_dict

--- a/frontend/app/components/import_process/content-mapping-step/content-mapping-step.component.html
+++ b/frontend/app/components/import_process/content-mapping-step/content-mapping-step.component.html
@@ -8,7 +8,7 @@
             <!-- Choix de la liste des nomenclatures -->
             <form class="was-validated">
                 <fieldset>
-                    <div *ngIf="cruvedStore?.cruved?.IMPORT.module_objects.MAPPING.cruved.R != '0'">
+                    <div *ngIf="cruvedStore?.cruved?.IMPORT?.module_objects.MAPPING.cruved.R != '0'">
                         <legend class="px-1">
                             Choix du modèle d'import
                         </legend>
@@ -33,7 +33,7 @@
                                 </div>
                                 <button 
                                     mat-icon-button
-                                    [disabled]="cruvedStore?.cruved?.IMPORT.module_objects.MAPPING.cruved.D == '0'"
+                                    [disabled]="!isRemovable()"
                                     (click)="removeModel()"
                                     matTooltip="Supprimer l'import"
                                     color=warn
@@ -46,7 +46,7 @@
                     <div class="row">
                         <div class="col">
                             <button
-                                *ngIf="cruvedStore?.cruved?.IMPORT.module_objects.MAPPING.cruved.C != '0'"
+                                *ngIf="cruvedStore?.cruved?.IMPORT?.module_objects.MAPPING.cruved.C != '0'"
                                 class="d-flex justify-content-center align-content-between mb-3"
                                 mat-raised-button
                                 color="primary"

--- a/frontend/app/components/import_process/content-mapping-step/content-mapping-step.component.html
+++ b/frontend/app/components/import_process/content-mapping-step/content-mapping-step.component.html
@@ -12,23 +12,34 @@
                         <legend class="px-1">
                             Choix du modèle d'import
                         </legend>
-                        <div class="form-group">
-                            <select
-                                class="form-control form-control-sm"
-                                id="contentMappingSelection"
-                                [compareWith]="compareFn"
-                                [formControl]="mappingListForm"
-                            >
-                                <option [ngValue]="null">
-                                    -
-                                </option>
-                                <option
-                                    *ngFor="let data of _cm.userContentMappings"
-                                    [ngValue]="data"
-                                >
-                                    {{data.mapping_label}}
-                                </option>
-                            </select>
+                        <div class="d-flex">
+                                <div class="form-group flex-fill">
+                                    <select
+                                        class="form-control form-control-sm"
+                                        id="contentMappingSelection"
+                                        [compareWith]="compareFn"
+                                        [formControl]="mappingListForm"
+                                    >
+                                        <option [ngValue]="null">
+                                            -
+                                        </option>
+                                        <option
+                                            *ngFor="let data of _cm.userContentMappings"
+                                            [ngValue]="data"
+                                        >
+                                            {{data.mapping_label}}
+                                        </option>
+                                    </select>
+                                </div>
+                                <button 
+                                    mat-icon-button
+                                    [disabled]="cruvedStore?.cruved?.IMPORT.module_objects.MAPPING.cruved.D == '0'"
+                                    (click)="removeModel()"
+                                    matTooltip="Supprimer l'import"
+                                    color=warn
+                                    >
+                                    <mat-icon>delete</mat-icon>
+                                </button>
                         </div>
                     </div>
 

--- a/frontend/app/components/import_process/content-mapping-step/content-mapping-step.component.ts
+++ b/frontend/app/components/import_process/content-mapping-step/content-mapping-step.component.ts
@@ -392,6 +392,11 @@ export class ContentMappingStepComponent implements OnInit {
     }
   }
 
+  isRemovable() {
+    const val = this.mappingListForm.value
+    return val === null ? false: val.cruved.D
+  }
+
   removeModel() {
     if (this.mappingListForm.value !== null) {
       this._ds.deleteMapping(this.id_mapping).subscribe(

--- a/frontend/app/components/import_process/content-mapping-step/content-mapping-step.component.ts
+++ b/frontend/app/components/import_process/content-mapping-step/content-mapping-step.component.ts
@@ -392,6 +392,14 @@ export class ContentMappingStepComponent implements OnInit {
     }
   }
 
+  removeModel() {
+    if (this.mappingListForm.value !== null) {
+      this._ds.deleteMapping(this.id_mapping).subscribe(
+        () => this._cm.getMappingNamesList()
+      )
+    }
+  }
+
   goToPreview() {    
     // if mapping change
     if(!this.contentTargetForm.pristine) {

--- a/frontend/app/components/import_process/fields-mapping-step/fields-mapping-step.component.html
+++ b/frontend/app/components/import_process/fields-mapping-step/fields-mapping-step.component.html
@@ -16,20 +16,31 @@
                         <legend class="px-1">
                             Choix du modèle d'import
                         </legend>
-                        <select
-                            class="form-control form-control-sm"
-                            id="mappingSelection"
-                            [formControl]="fieldMappingForm"
-                            [compareWith]="compareFn"
-                            [disableControl]="userFieldMappings.length == 1"
-                        >
-                            <option [ngValue]="null"> - </option>
-                            <option
-                                *ngFor="let data of userFieldMappings"
-                                [ngValue]="data"
+                        <div class="d-flex">
+                            <select
+                                class="form-control form-control-sm flex-fill"
+                                id="mappingSelection"
+                                [formControl]="fieldMappingForm"
+                                [compareWith]="compareFn"
+                                [disableControl]="userFieldMappings.length == 1"
                             >
-                                {{data.mapping_label}}</option>
-                        </select>
+                                <option [ngValue]="null"> - </option>
+                                <option
+                                    *ngFor="let data of userFieldMappings"
+                                    [ngValue]="data"
+                                >
+                                    {{data.mapping_label}}</option>
+                            </select>
+                            <button 
+                                mat-icon-button
+                                [disabled]="cruvedStore?.cruved?.IMPORT.module_objects.MAPPING.cruved.D == '0'"
+                                (click)="removeModel()"
+                                matTooltip="Supprimer l'import"
+                                color=warn
+                            >
+                                <mat-icon>delete</mat-icon>
+                            </button>
+                        </div>
                     </div>
                     <div class="d-flex flex-row justify-content-between mt-3">
 

--- a/frontend/app/components/import_process/fields-mapping-step/fields-mapping-step.component.html
+++ b/frontend/app/components/import_process/fields-mapping-step/fields-mapping-step.component.html
@@ -12,7 +12,7 @@
             <!-- Choix de la liste des nomenclatures -->
             <form class="was-validated">
                 <fieldset>
-                    <div *ngIf="cruvedStore?.cruved?.IMPORT.module_objects.MAPPING.cruved.R != '0'">
+                    <div *ngIf="cruvedStore?.cruved?.IMPORT?.module_objects.MAPPING.cruved.R != '0'">
                         <legend class="px-1">
                             Choix du modèle d'import
                         </legend>
@@ -33,7 +33,7 @@
                             </select>
                             <button 
                                 mat-icon-button
-                                [disabled]="cruvedStore?.cruved?.IMPORT.module_objects.MAPPING.cruved.D == '0'"
+                                [disabled]="!isRemovable()"
                                 (click)="removeModel()"
                                 matTooltip="Supprimer l'import"
                                 color=warn
@@ -46,7 +46,7 @@
 
                         <div class="d-flex justify-content-center align-content-between">
                             <button
-                                *ngIf="cruvedStore?.cruved?.IMPORT.module_objects.MAPPING.cruved.C != '0'"
+                                *ngIf="cruvedStore?.cruved?.IMPORT?.module_objects.MAPPING.cruved.C != '0'"
                                 class="mb-3"
                                 mat-raised-button
                                 color="primary"
@@ -55,7 +55,7 @@
                                 Nouveau modèle d'import
                             </button>
                             <button
-                                *ngIf="cruvedStore?.cruved?.IMPORT.module_objects.MAPPING.cruved.U != '0' && fieldMappingForm?.value?.cruved.U"
+                                *ngIf="cruvedStore?.cruved?.IMPORT?.module_objects.MAPPING.cruved.U != '0' && fieldMappingForm?.value?.cruved.U"
                                 class="btn-sm mb-3 ml-1"
                                 mat-raised-button
                                 color="primary"

--- a/frontend/app/components/import_process/fields-mapping-step/fields-mapping-step.component.ts
+++ b/frontend/app/components/import_process/fields-mapping-step/fields-mapping-step.component.ts
@@ -654,4 +654,12 @@ export class FieldsMappingStepComponent implements OnInit {
       targetForm.get(key).setValue("");
     });
   }
+
+  removeModel() {
+    if (this.fieldMappingForm.value !== null) {
+      this._ds.deleteMapping(this.id_mapping).subscribe(
+        () => this.getMappingNamesList("field")
+      )
+    }
+  }
 }

--- a/frontend/app/components/import_process/fields-mapping-step/fields-mapping-step.component.ts
+++ b/frontend/app/components/import_process/fields-mapping-step/fields-mapping-step.component.ts
@@ -655,6 +655,11 @@ export class FieldsMappingStepComponent implements OnInit {
     });
   }
 
+  isRemovable() {
+    const val = this.fieldMappingForm.value
+    return val === null ? false: val.cruved.D
+  }
+
   removeModel() {
     if (this.fieldMappingForm.value !== null) {
       this._ds.deleteMapping(this.id_mapping).subscribe(


### PR DESCRIPTION
## Objectif

Permettre de supprimer un modèle de champs ou de nomenclature.

## Implémentation

Très simple : il suffit de sélectionner un modèle et de cliquer sur la corbeille. Il n'y a pas encore de confirmation de suppression.