### PR TITLE
Feat/id source

### DIFF
--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -95,20 +95,7 @@ class TImports(ModelCruvedAutorization):
         import_as_dict["dataset_name"] = import_as_dict["dataset"]["dataset_name"]
         import_as_dict.pop("dataset")
         import_as_dict["errors"] = import_as_dict.get("errors", [])
-
-        if self.id_source_synthese is None:
-            name_source = "Import(id=" + str(self.id_import) + ")"
-            id_source = None
-            source = (
-                DB.session.query(TSources.id_source)
-                .filter(TSources.name_source == name_source)
-                .first()
-            )
-            if source:
-                id_source = source[0]
-            import_as_dict["id_source"] = id_source
-        else:
-            import_as_dict["id_source"] = self.id_source_synthese
+        import_as_dict["id_source"] = self.id_source_synthese
         return import_as_dict
 
 

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -95,16 +95,20 @@ class TImports(ModelCruvedAutorization):
         import_as_dict["dataset_name"] = import_as_dict["dataset"]["dataset_name"]
         import_as_dict.pop("dataset")
         import_as_dict["errors"] = import_as_dict.get("errors", [])
-        # name_source = "Import(id=" + str(self.id_import) + ")"
-        # id_source = None
-        # source = (
-        #     DB.session.query(TSources.id_source)
-        #     .filter(TSources.name_source == name_source)
-        #     .first()
-        # )
-        # if source:
-        #     id_source = source[0]
-        # import_as_dict["id_source"] = id_source
+
+        if self.id_source_synthese is None:
+            name_source = "Import(id=" + str(self.id_import) + ")"
+            id_source = None
+            source = (
+                DB.session.query(TSources.id_source)
+                .filter(TSources.name_source == name_source)
+                .first()
+            )
+            if source:
+                id_source = source[0]
+            import_as_dict["id_source"] = id_source
+        else:
+            import_as_dict["id_source"] = self.id_source_synthese
         return import_as_dict
 
 

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -46,6 +46,7 @@ class TImports(ModelCruvedAutorization):
     __table_args__ = {"schema": "gn_imports", "extend_existing": True}
 
     id_import = DB.Column(DB.Integer, primary_key=True, autoincrement=True)
+    id_source_synthese = DB.Column(DB.Integer, ForeignKey("gn_synthese.t_sources.id_source"), nullable=True)
     format_source_file = DB.Column(DB.Unicode, nullable=True)
     srid = DB.Column(DB.Integer, nullable=True)
     separator = DB.Column(DB.Unicode, nullable=True)
@@ -94,16 +95,16 @@ class TImports(ModelCruvedAutorization):
         import_as_dict["dataset_name"] = import_as_dict["dataset"]["dataset_name"]
         import_as_dict.pop("dataset")
         import_as_dict["errors"] = import_as_dict.get("errors", [])
-        name_source = "Import(id=" + str(self.id_import) + ")"
-        id_source = None
-        source = (
-            DB.session.query(TSources.id_source)
-            .filter(TSources.name_source == name_source)
-            .first()
-        )
-        if source:
-            id_source = source[0]
-        import_as_dict["id_source"] = id_source
+        # name_source = "Import(id=" + str(self.id_import) + ")"
+        # id_source = None
+        # source = (
+        #     DB.session.query(TSources.id_source)
+        #     .filter(TSources.name_source == name_source)
+        #     .first()
+        # )
+        # if source:
+        #     id_source = source[0]
+        # import_as_dict["id_source"] = id_source
         return import_as_dict
 
 

--- a/backend/routes/download_to_synthese.py
+++ b/backend/routes/download_to_synthese.py
@@ -10,7 +10,9 @@ from geonature.core.gn_permissions import decorators as permissions
 from ..db.models import TImports, TMappings
 
 from ..db.queries.save_mapping import get_selected_columns
-from ..db.queries.load_to_synthese import insert_into_t_sources, check_id_source
+from ..db.queries.load_to_synthese import (insert_into_t_sources, 
+                                           check_id_source,
+                                           get_id_source)
 from ..db.queries.user_table_queries import (
     set_imports_table_name,
     get_table_name,
@@ -182,6 +184,8 @@ def finalize_import(id_import, table_name, total_columns):
     import_obj.is_finished = True
     import_obj.processing = False
     import_obj.in_error = False
+    # Get id_source from t_sources table
+    import_obj.id_source_synthese = get_id_source(id_import)
 
     logger.info("-> t_imports updated on final step")
 

--- a/data/import_db.sql
+++ b/data/import_db.sql
@@ -259,6 +259,9 @@ ALTER TABLE ONLY cor_role_import
  ALTER TABLE ONLY cor_role_import
  ADD CONSTRAINT fk_cor_role_import_import FOREIGN KEY (id_import) REFERENCES gn_imports.t_imports(id_import) ON UPDATE CASCADE ON DELETE CASCADE;
 
+-- ALTER table gn_imports.t_imports add column id_source_synthese int4 null;
+alter table only gn_imports.t_imports
+    ADD CONSTRAINT fk_gn_imports_t_import_id_source_synthese FOREIGN KEY (id_source_synthese) REFERENCES gn_synthese.t_sources(id_source) ON UPDATE set null;
 ---------------------
 --OTHER CONSTRAINTS--
 ---------------------

--- a/data/import_db.sql
+++ b/data/import_db.sql
@@ -259,9 +259,9 @@ ALTER TABLE ONLY cor_role_import
  ALTER TABLE ONLY cor_role_import
  ADD CONSTRAINT fk_cor_role_import_import FOREIGN KEY (id_import) REFERENCES gn_imports.t_imports(id_import) ON UPDATE CASCADE ON DELETE CASCADE;
 
--- ALTER table gn_imports.t_imports add column id_source_synthese int4 null;
-alter table only gn_imports.t_imports
-    ADD CONSTRAINT fk_gn_imports_t_import_id_source_synthese FOREIGN KEY (id_source_synthese) REFERENCES gn_synthese.t_sources(id_source) ON UPDATE set null;
+-- ALTER table gn_imports.t_imports add column id_source_synthese int4 default null;
+ALTER TABLE only gn_imports.t_imports
+    ADD CONSTRAINT fk_gn_imports_t_import_id_source_synthese FOREIGN KEY (id_source_synthese) REFERENCES gn_synthese.t_sources(id_source) ON UPDATE SET NULL ON DELETE CASCADE;
 ---------------------
 --OTHER CONSTRAINTS--
 ---------------------

--- a/data/import_db.sql
+++ b/data/import_db.sql
@@ -259,7 +259,7 @@ ALTER TABLE ONLY cor_role_import
  ALTER TABLE ONLY cor_role_import
  ADD CONSTRAINT fk_cor_role_import_import FOREIGN KEY (id_import) REFERENCES gn_imports.t_imports(id_import) ON UPDATE CASCADE ON DELETE CASCADE;
 
--- ALTER table gn_imports.t_imports add column id_source_synthese int4 default null;
+ALTER table gn_imports.t_imports add column id_source_synthese int4 default null;
 ALTER TABLE only gn_imports.t_imports
     ADD CONSTRAINT fk_gn_imports_t_import_id_source_synthese FOREIGN KEY (id_source_synthese) REFERENCES gn_synthese.t_sources(id_source) ON UPDATE SET NULL ON DELETE CASCADE;
 ---------------------

--- a/data/migration/1.1.2toDev.sql
+++ b/data/migration/1.1.2toDev.sql
@@ -2,7 +2,7 @@
 -- Add id_source column
 -----------------------
 ALTER TABLE only gn_imports.t_imports
-  ADD CONSTRAINT fk_gn_imports_t_import_id_source_synthese FOREIGN KEY (id_source_synthese) REFERENCES gn_synthese.t_sources(id_source) ON UPDATE SET NULL ON DELETE CASCADE;
+  ADD CONSTRAINT fk_gn_imports_t_import_id_source_synthese FOREIGN KEY (id_source_synthese) REFERENCES gn_synthese.t_sources(id_source) ON UPDATE CASCADE ON DELETE CASCADE;
 -- Populate id_source column
 UPDATE gn_imports.t_imports
 SET id_source_synthese = s.id_source

--- a/data/migration/1.1.2toDev.sql
+++ b/data/migration/1.1.2toDev.sql
@@ -1,0 +1,10 @@
+-----------------------
+-- Add id_source column
+-----------------------
+ALTER TABLE only gn_imports.t_imports
+  ADD CONSTRAINT fk_gn_imports_t_import_id_source_synthese FOREIGN KEY (id_source_synthese) REFERENCES gn_synthese.t_sources(id_source) ON UPDATE SET NULL ON DELETE CASCADE;
+-- Populate id_source column
+UPDATE gn_imports.t_imports
+SET id_source_synthese = s.id_source
+FROM gn_synthese.t_sources s
+WHERE s.name_source='Import(id='||id_import||')'


### PR DESCRIPTION
## Objectif
Ajout d'un champ `id_source_synthese` dans la table `t_imports` pour faire un lien avec la table `t_sources` du schéma `gn_synthese`.

## Implémentation
- [x] Ajout d'une colonne et une contrainte associée dans `t_imports` comme suit : 
  ```sql
  ALTER table gn_imports.t_imports add column id_source_synthese int4 null;
  ALTER table only gn_imports.t_imports
      ADD CONSTRAINT fk_gn_imports_t_import_id_source_synthese FOREIGN KEY (id_source_synthese) REFERENCES gn_synthese.t_sources(id_source) ON UPDATE SET NULL ON DELETE CASCADE;
  ```

- [x] En attendant un script de "remplissage" des `id_source_synthese` des imports existants (voir ci-après), ajout d'une condition (https://github.com/mvergez/gn_module_import/blob/2920471a617fc730bb2aaeb8726bf1aadfe0f27b/backend/db/models.py#L99) pour calculer l'id_source s'il n'est pas disponible dans la table `t_imports`
- [x] Ajout d'un script sql permettant de compléter les `id_source_synthese` des imports existants

Closes #201 