### PR TITLE
feat/improve-import-model

### DIFF
--- a/backend/db/queries/nomenclatures.py
+++ b/backend/db/queries/nomenclatures.py
@@ -80,7 +80,8 @@ def get_nomenc_values(nommenclature_abb):
             nom.id_nomenclature AS nomenc_id,
             nom.cd_nomenclature AS nomenc_cd,
             nom.label_default AS nomenc_values, 
-            nom.definition_default AS nomenc_definitions
+            nom.definition_default AS nomenc_definitions,
+            bib.mnemonique AS nomenc_mnemo
         FROM ref_nomenclatures.bib_nomenclatures_types AS bib
         JOIN ref_nomenclatures.t_nomenclatures AS nom ON nom.id_type = bib.id_type
         WHERE bib.mnemonique = :nomenc

--- a/backend/db/queries/nomenclatures.py
+++ b/backend/db/queries/nomenclatures.py
@@ -78,6 +78,7 @@ def get_nomenclature_values(mnemoniques_type: list):
 def get_nomenc_values(nommenclature_abb):
     query = """SELECT
             nom.id_nomenclature AS nomenc_id,
+            nom.cd_nomenclature AS nomenc_cd,
             nom.label_default AS nomenc_values, 
             nom.definition_default AS nomenc_definitions
         FROM ref_nomenclatures.bib_nomenclatures_types AS bib

--- a/backend/transform/nomenclatures/nomenclatures.py
+++ b/backend/transform/nomenclatures/nomenclatures.py
@@ -353,6 +353,7 @@ def get_nomenc_info(form_data, schema_name, table_name):
                     "value": val.nomenc_values,
                     "definition": val.nomenc_definitions,
                     "name": clean_string(val.nomenc_values),
+                    "cd_nomenclature": str(val.nomenc_cd),
                 }
                 val_def_list.append(d)
 

--- a/backend/transform/nomenclatures/nomenclatures.py
+++ b/backend/transform/nomenclatures/nomenclatures.py
@@ -354,6 +354,7 @@ def get_nomenc_info(form_data, schema_name, table_name):
                     "definition": val.nomenc_definitions,
                     "name": clean_string(val.nomenc_values),
                     "cd_nomenclature": str(val.nomenc_cd),
+                    "mnemonique": str(val.nomenc_mnemo),
                 }
                 val_def_list.append(d)
 

--- a/frontend/app/components/import_process/content-mapping-step/content-mapping-step.component.html
+++ b/frontend/app/components/import_process/content-mapping-step/content-mapping-step.component.html
@@ -8,7 +8,7 @@
             <!-- Choix de la liste des nomenclatures -->
             <form class="was-validated">
                 <fieldset>
-                    <div *ngIf="cruvedStore?.cruved?.IMPORT.module_objects.MAPPING.cruved.R != '0'">
+                    <div *ngIf="cruvedStore?.cruved?.IMPORT?.module_objects.MAPPING.cruved.R != '0'">
                         <legend class="px-1">
                             Choix du modèle d'import
                         </legend>
@@ -35,7 +35,7 @@
                     <div class="row">
                         <div class="col">
                             <button
-                                *ngIf="cruvedStore?.cruved?.IMPORT.module_objects.MAPPING.cruved.C != '0'"
+                                *ngIf="cruvedStore?.cruved?.IMPORT?.module_objects.MAPPING.cruved.C != '0'"
                                 class="d-flex justify-content-center align-content-between mb-3"
                                 mat-raised-button
                                 color="primary"
@@ -46,7 +46,7 @@
                         </div>
                         <div class="col">
                             <button
-                                *ngIf="cruvedStore?.cruved?.IMPORT.module_objects.MAPPING.cruved.C != '0'"
+                                *ngIf="cruvedStore?.cruved?.IMPORT?.module_objects.MAPPING.cruved.C != '0'"
                                 class="d-flex justify-content-center align-content-between mb-3"
                                 mat-raised-button
                                 color="primary"

--- a/frontend/app/components/import_process/content-mapping-step/content-mapping-step.component.ts
+++ b/frontend/app/components/import_process/content-mapping-step/content-mapping-step.component.ts
@@ -253,10 +253,28 @@ export class ContentMappingStepComponent implements OnInit {
   }
 
   loadMapping(data) {
+    // Set the proper ids by matching mnemonique and cd_nomenclature
+    // between data and content_mapping_info
+    data = this.correctMapping(data)
     // Since the exported json is of the same format
     // as the field one, we need to transform it to the correct format
     // (see API calls)
     this.fillFormFromMappings(data.map(e => [e]))
+  }
+
+  correctMapping(data) {
+    return data.map((element) => {
+      const nomenc = this.stepData.contentMappingInfo.filter(
+        (content) => content.nomenc_abbr == element.mnemonique
+      )[0];
+      if (nomenc) {
+        const _id = nomenc.nomenc_values_def.filter(
+          (val) => val.cd_nomenclature == element.cd_nomenclature
+        )[0];
+        element.id_target_value = _id.id;
+      }
+      return element
+    });
   }
 
   isEnabled(value_def_id: string) {

--- a/frontend/app/components/import_process/content-mapping-step/content-mapping-step.component.ts
+++ b/frontend/app/components/import_process/content-mapping-step/content-mapping-step.component.ts
@@ -132,6 +132,38 @@ export class ContentMappingStepComponent implements OnInit {
       );
   }
 
+  saveMappingName(value) {
+    // save new mapping in bib_mapping
+    // then select the mapping name in the select
+    let mappingType = "CONTENT";
+    const mappingForm = {
+      mappingName: this.newMappingNameForm.value
+    };
+    this._ds.postMappingName(mappingForm, mappingType).subscribe(
+        (id_mapping) => {
+            this._cm.newMapping = false;
+            this._cm
+                .getMappingNamesListMap(id_mapping, this.mappingListForm)
+                .toPromise()
+                .then(() => {});
+            this.newMappingNameForm.reset();
+            //this.enableMapping(targetForm);
+        },
+      (error) => {
+        if (error.statusText === "Unknown Error") {
+          // show error message if no connexion
+          this._commonService.regularToaster(
+            "error",
+            "Une erreur s'est produite : contactez l'administrateur du site"
+          );
+        } else {
+          console.log(error);
+          this._commonService.regularToaster("error", error.error);
+        }
+      }
+    );
+  }
+
   saveMappingNameForJson(jsonfile) {
     // save new mapping in bib_mapping
     // then select the mapping name in the select
@@ -260,6 +292,13 @@ export class ContentMappingStepComponent implements OnInit {
     // as the field one, we need to transform it to the correct format
     // (see API calls)
     this.fillFormFromMappings(data.map(e => [e]))
+    this._ds
+        .updateContentMapping(this.id_mapping, this.contentTargetForm.value)
+        .toPromise()
+        .then(() => {})
+        .catch((error) =>
+          this._commonService.regularToaster("error", error.error.message)
+        );
   }
 
   correctMapping(data) {
@@ -271,7 +310,7 @@ export class ContentMappingStepComponent implements OnInit {
         const _id = nomenc.nomenc_values_def.filter(
           (val) => val.cd_nomenclature == element.cd_nomenclature
         )[0];
-        element.id_target_value = _id.id;
+        element.id_target_value = parseInt(_id.id);
       }
       return element
     });

--- a/frontend/app/components/import_process/content-mapping-step/content-mapping-step.component.ts
+++ b/frontend/app/components/import_process/content-mapping-step/content-mapping-step.component.ts
@@ -13,7 +13,7 @@ import { ContentMappingService } from "../../../services/mappings/content-mappin
 import { CommonService } from "@geonature_common/service/common.service";
 import { CruvedStoreService } from "@geonature_common/service/cruved-store.service";
 import { ModuleConfig } from "../../../module.config";
-import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
+import { NgbModal, NgbModalRef } from "@ng-bootstrap/ng-bootstrap";
 
 
 @Component({
@@ -54,7 +54,7 @@ export class ContentMappingStepComponent implements OnInit {
   @ViewChild("modalConfirm") modalConfirm: any;
   @ViewChild("modalRedir") modalRedir: any;
   @ViewChild("modalImport") modalImport: any;
-  public modalImportVar: NgbModal;
+  public modalImportVar: NgbModalRef;
 
   constructor(
     private stepService: StepsService,

--- a/frontend/app/components/import_process/fields-mapping-step/fields-mapping-step.component.ts
+++ b/frontend/app/components/import_process/fields-mapping-step/fields-mapping-step.component.ts
@@ -19,7 +19,7 @@ import {
   Step4Data
 } from "../steps.service";
 import { forkJoin } from "rxjs/observable/forkJoin";
-import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
+import { NgbModal, NgbModalRef } from "@ng-bootstrap/ng-bootstrap";
 import { FileService } from "../../../services/file.service";
 
 
@@ -63,7 +63,7 @@ export class FieldsMappingStepComponent implements OnInit {
   @ViewChild("modalConfirm") modalConfirm: any;
   @ViewChild("modalRedir") modalRedir: any;
   @ViewChild("modalImport") modalImport: any;
-  public modalImportVar: NgbModal;
+  public modalImportVar: NgbModalRef;
   @ViewChild("modalNoNomenc") modalNoNomenc: any;
   
   constructor(

--- a/frontend/app/components/import_process/import-step/import-step.component.ts
+++ b/frontend/app/components/import_process/import-step/import-step.component.ts
@@ -79,8 +79,6 @@ export class ImportStepComponent implements OnInit {
         this.spinner = true;
         this._ds.importData(this.idImport).subscribe(
             res => {
-                console.log(res);
-
                 this.spinner = false;
 
                 this.stepService.resetStepoer();

--- a/frontend/app/components/import_report/import_report.component.ts
+++ b/frontend/app/components/import_report/import_report.component.ts
@@ -151,7 +151,10 @@ export class ImportReportComponent implements OnInit, OnDestroy {
                             // source value, needs to rename
                             val.target_value = val.source_value
                             val.source_value = elm.value;
-                            val.definition = elm.definition}
+                            val.definition = elm.definition;
+                            val.cd_nomenclature = elm.cd_nomenclature;
+                            val.mnemonique = elm.mnemonique;
+                        }
                             )[0]
                     )
         }

--- a/frontend/app/components/import_report/import_report.component.ts
+++ b/frontend/app/components/import_report/import_report.component.ts
@@ -138,7 +138,6 @@ export class ImportReportComponent implements OnInit, OnDestroy {
         
         if (sourceValues.length > 0) {
             this.matchedNomenclature = this.contentMapping.map(elm => elm[0])
-            
             // For each values in target_values (this.matchedNomenclature)
             // filter with the id of target_values with the id of source
             // values to get the actual value
@@ -146,7 +145,7 @@ export class ImportReportComponent implements OnInit, OnDestroy {
             this.matchedNomenclature.forEach(
                 val => sourceValues.filter(
                     elm => parseInt(elm.id) == val.id_target_value).map(
-                        function(elm) {
+                        elm => {
                             // Carefull the target_value is actually the
                             // source value, needs to rename
                             val.target_value = val.source_value
@@ -154,8 +153,8 @@ export class ImportReportComponent implements OnInit, OnDestroy {
                             val.definition = elm.definition;
                             val.cd_nomenclature = elm.cd_nomenclature;
                             val.mnemonique = elm.mnemonique;
-                        }
-                            )[0]
+                            }
+                        )[0]
                     )
         }
     }

--- a/frontend/app/components/import_report/import_report.component.ts
+++ b/frontend/app/components/import_report/import_report.component.ts
@@ -143,19 +143,23 @@ export class ImportReportComponent implements OnInit, OnDestroy {
             // values to get the actual value
             // Then affect the target_value and the definition
             this.matchedNomenclature.forEach(
-                val => sourceValues.filter(
-                    elm => parseInt(elm.id) == val.id_target_value).map(
-                        elm => {
-                            // Carefull the target_value is actually the
-                            // source value, needs to rename
-                            val.target_value = val.source_value
-                            val.source_value = elm.value;
-                            val.definition = elm.definition;
-                            val.cd_nomenclature = elm.cd_nomenclature;
-                            val.mnemonique = elm.mnemonique;
-                            }
-                        )[0]
-                    )
+                (val) =>
+                    sourceValues
+                    .filter((elm) => parseInt(elm.id) == val.id_target_value)
+                    .map((elm) => {
+                        // Carefull the target_value is actually the
+                        // source value, needs to rename
+                        val.target_value = val.source_value;
+                        val.source_value = elm.value;
+                        val.definition = elm.definition;
+                        val.cd_nomenclature = elm.cd_nomenclature;
+                        val.mnemonique = elm.mnemonique;
+                        val.nomenc_synthese_name =
+                        this.nomenclature.content_mapping_info.filter(
+                            (item) => item.nomenc_abbr == val.mnemonique
+                        )[0].nomenc_synthese_name;
+                    })[0]
+                );
         }
     }
 
@@ -198,8 +202,26 @@ export class ImportReportComponent implements OnInit, OnDestroy {
     exportNomenclatures() {
         // Exactly like the correspondances
         if (this.matchedNomenclature) {
-            const blob = new Blob([JSON.stringify(this.matchedNomenclature, null, 4)], 
-                                {type : 'application/json'});
+            // keys to export
+            const toExport = [
+                "nomenc_synthese_name",
+                "source_value",
+                "cd_nomenclature",
+                "mnemonique",
+            ];
+            // Taken on https://stackoverflow.com/questions/34658867/slice-specific-keys-in-javascript-object/53202834
+            const pick = (obj, ...args) => ({
+                ...args.reduce((res, key) => ({ ...res, [key]: obj[key] }), {}),
+            });
+            // For all obj in this.matchedNomenclature pick only the toExport
+            // keys
+            const filtered = this.matchedNomenclature.map((item) =>
+                pick(item, ...toExport)
+            );
+            // Export
+            const blob = new Blob([JSON.stringify(filtered, null, 4)], {
+                type: "application/json",
+            });
             saveAs(blob, "nomenclatures.json");
         }
     }

--- a/frontend/app/components/modal_dataset/import-modal-dataset.component.ts
+++ b/frontend/app/components/modal_dataset/import-modal-dataset.component.ts
@@ -33,8 +33,6 @@ export class ImportModalDatasetComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.selectDatasetForm = new FormControl(null, Validators.required);
-    console.log(this.cruvedStore.cruved);
-    
   }
 
   onOpenModal(content) {

--- a/frontend/app/services/data.service.ts
+++ b/frontend/app/services/data.service.ts
@@ -225,7 +225,6 @@ export class DataService {
     // formData.append("chart", new Blob([chartImg], {type: 'image/png'}), "chart");
     formData.append("map", mapImg);
     formData.append("chart", chartImg);
-    console.log(formData)
     return this._http.post(`${urlApi}/export_pdf/${importId}`, 
                            formData, {responseType: 'blob'});
   }

--- a/frontend/app/services/mappings/content-mapping.service.ts
+++ b/frontend/app/services/mappings/content-mapping.service.ts
@@ -1,7 +1,9 @@
-import { Injectable, Observable} from "@angular/core";
+import { Injectable } from "@angular/core";
 import { DataService } from "../data.service";
 import { CommonService } from "@geonature_common/service/common.service";
 import { ModuleConfig } from "../../module.config";
+import { Observable } from "rxjs";
+
 
 @Injectable()
 export class ContentMappingService {
@@ -17,7 +19,7 @@ export class ContentMappingService {
     this.displayMapped = ModuleConfig.DISPLAY_MAPPED_VALUES;
   }
 
-  getMappingNamesListMap(newContentId?, formControl?): Observable<number | null>{
+  getMappingNamesListMap(newContentId?, formControl?): Observable<number | void>{
     // get list of existing content mapping in the select
     return this._ds.getMappings("content").map(
       result => {


### PR DESCRIPTION
## Objectif
Suite à la PR [233](https://github.com/PnX-SI/gn_module_import/pull/233), amélioration du traitement du fichier json contenant les correspondances de nomenclatures.

En effet, cette correspondance se base sur les `id_nomenclature` en base de donnée qui peuvent être différents d'une instance de GeoNature à l'autre. L'objectif était donc d'exporter dans le json le `cd_nomenclature` et le `mnemonique` pour retrouver les `id_nomenclature` de l'instance et les "corriger" après avoir chargé le .json.

## Implémentation
- Ajout du `cd_nomenclature` et du `mnemonique` dans le fichier json des nomenclatures exporté depuis le rapport d'import
- Au chargement du fichier json à l'étape des correspondances de nomenclature : remplacement des `id_target_value` (qui ciblent le `id_nomenclature`) par les `id_nomenclature` de l'instance courante de GeoNature via le `content_mapping_info`. Cette étape précède l'association des champs (qui est fait lorsqu'on sélectionne un modèle de correspondances). 

## Améliorations
- Le json est parcouru en entier et tous les `id_target_value` sont remplacés même ceux identiques : à optimiser.
- Changer la façon dont est fait le mapping des nomenclature (ne pas se baser sur les `id_nomenclature`) : aurait demandé un trop gros refact et, par manque de temps, je ne me suis pas lancé là dedans.
- (sera peut être fait) : diminution des données exportées dans le json. Seuls le `cd_nomenclature`, `mnemonique` et `source_value` sont nécessaires (j'ai testé).
- Sûrement d'autres...

## Divers
Cette PR implémente aussi un Fix car le frontend ne compile actuellement pas sur la branche project-FLA_NS


Closes #146 