### PR TITLE
Add leaflet-image package

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,13 +1,55 @@
 {
   "name": "gn_module_import",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "gn_module_import",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "file-saver": "^2.0.2",
+        "leaflet-image": "^0.4.0"
+      }
+    },
+    "node_modules/d3-queue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/d3-queue/-/d3-queue-2.0.3.tgz",
+      "integrity": "sha512-ejbdHqZYEmk9ns/ljSbEcD6VRiuNwAkZMdFf6rsUb3vHROK5iMFd8xewDQnUVr6m/ba2BG63KmR/LySfsluxbg=="
+    },
+    "node_modules/file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
+    },
+    "node_modules/leaflet-image": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/leaflet-image/-/leaflet-image-0.4.0.tgz",
+      "integrity": "sha512-J/vLCHiYNXlcQ/SZbHhj/VF5k3thxTryWijoqMO9sB20KV7hlMNUZDgxcDzXnfjk4hcYcFfGbveVc1tyQ9FgYw==",
+      "dependencies": {
+        "d3-queue": "2.0.3"
+      }
+    }
+  },
   "dependencies": {
+    "d3-queue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/d3-queue/-/d3-queue-2.0.3.tgz",
+      "integrity": "sha512-ejbdHqZYEmk9ns/ljSbEcD6VRiuNwAkZMdFf6rsUb3vHROK5iMFd8xewDQnUVr6m/ba2BG63KmR/LySfsluxbg=="
+    },
     "file-saver": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
       "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
+    },
+    "leaflet-image": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/leaflet-image/-/leaflet-image-0.4.0.tgz",
+      "integrity": "sha512-J/vLCHiYNXlcQ/SZbHhj/VF5k3thxTryWijoqMO9sB20KV7hlMNUZDgxcDzXnfjk4hcYcFfGbveVc1tyQ9FgYw==",
+      "requires": {
+        "d3-queue": "2.0.3"
+      }
     }
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "file-saver": "^2.0.2"
+    "file-saver": "^2.0.2",
+    "leaflet-image": "^0.4.0"
   }
 }


### PR DESCRIPTION
As it is required for Import report and was removed recently from GeoNature (https://github.com/PnX-SI/GeoNature/commit/a65bb03706d033ba0f5f8f92301a27538244ae9f#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L69).

Require to regenerate ``package-lock.json`` before merging.