### PR TITLE
fill missing values with default nomenclature

### DIFF
--- a/backend/gn_module_import/conf_schema_toml.py
+++ b/backend/gn_module_import/conf_schema_toml.py
@@ -131,7 +131,7 @@ class GnModuleSchemaConf(Schema):
     INVALID_CSV_NAME = fields.String(load_default=INVALID_CSV_NAME)
     ALLOW_VALUE_MAPPING = fields.Boolean(load_default=ALLOW_VALUE_MAPPING)
     DEFAULT_VALUE_MAPPING_ID = fields.Integer(load_default=DEFAULT_VALUE_MAPPING_ID)
-    FILL_MISSING_NOMENCLATURE_WITH_DEFAULT_VALUE = fields.Boolean(load_default=False)
+    FILL_MISSING_NOMENCLATURE_WITH_DEFAULT_VALUE = fields.Boolean(load_default=True)
     # Parameter to define if the mapped fields are displayed or not.
     DISPLAY_MAPPED_VALUES = fields.Boolean(load_default=True)
     DISPLAY_CHECK_BOX_MAPPED_VALUES = fields.Boolean(load_default=True)

--- a/backend/gn_module_import/tests/files/digital_proof.csv
+++ b/backend/gn_module_import/tests/files/digital_proof.csv
@@ -1,9 +1,17 @@
-date_min;date_max;hour_min;hour_max;nom_cite;observateurs;WKT;cd_nom;digital_proof;Erreur(s) attendue(s)
-2017-01-01;2017-01-01;;;Ablette;Toto;POINT(6.5 44.85);67111;https://test.fr;Valide
-2017-01-01;2017-01-01;20:00;;Ablette;Toto;POINT(6.5 44.85);67111;http:/ik.fr;INVALID_URL_PROOF
-2017-01-01;2017-01-01;;20:00;Ablette;Toto;POINT(6.5 44.85);67111;http://178.32.193.151;Valide
-2017-01-01;2017-01-01;20:00;20:00;Ablette;Toto;POINT(6.5 44.85);67111;htt://ik.fr;INVALID_URL_PROOF
-2017-01-01;2017-01-01;20:00;21:00;Ablette;Toto;POINT(6.5 44.85);67111;http://ik;INVALID_URL_PROOF
-2017-01-01;2017-01-01;20:00;21:00;Ablette;Toto;POINT(6.5 44.85);67111;geonature.fr;Valide
-2017-01-01;2017-01-01;;;Ablette;Toto;POINT(6.5 44.85);67111;ftp://test.com;Valide
-2017-01-01;2017-01-01;;;Ablette;Toto;POINT(6.5 44.85);67111;;Valide
+date_min;date_max;hour_min;hour_max;nom_cite;observateurs;WKT;cd_nom;id_nomenclature_exist_proof;digital_proof;Erreur(s) attendue(s)
+2017-01-01;2017-01-01;;;Ablette;Toto;POINT(6.5 44.85);67111;Oui;https://test.fr;Valide
+2017-01-01;2017-01-01;20:00;;Ablette;Toto;POINT(6.5 44.85);67111;Oui;http:/ik.fr;INVALID_URL_PROOF
+2017-01-01;2017-01-01;;20:00;Ablette;Toto;POINT(6.5 44.85);67111;Oui;http://178.32.193.151;Valide
+2017-01-01;2017-01-01;20:00;20:00;Ablette;Toto;POINT(6.5 44.85);67111;Oui;htt://ik.fr;INVALID_URL_PROOF
+2017-01-01;2017-01-01;20:00;21:00;Ablette;Toto;POINT(6.5 44.85);67111;Oui;http://ik;INVALID_URL_PROOF
+2017-01-01;2017-01-01;20:00;21:00;Ablette;Toto;POINT(6.5 44.85);67111;Oui;geonature.fr;Valide
+2017-01-01;2017-01-01;;;Ablette;Toto;POINT(6.5 44.85);67111;Oui;ftp://test.com;Valide
+2017-01-01;2017-01-01;;;Ablette;Toto;POINT(6.5 44.85);67111;Oui;;INVALID_EXISTING_PROOF_VALUE
+2017-01-01;2017-01-01;;;Ablette;Toto;POINT(6.5 44.85);67111;Non;geonature.fr;INVALID_EXISTING_PROOF_VALUE
+2017-01-01;2017-01-01;;;Ablette;Toto;POINT(6.5 44.85);67111;Non;;Valide
+2017-01-01;2017-01-01;;;Ablette;Toto;POINT(6.5 44.85);67111;Non acquise;geonature.fr;INVALID_EXISTING_PROOF_VALUE
+2017-01-01;2017-01-01;;;Ablette;Toto;POINT(6.5 44.85);67111;Non acquise;;Valide
+2017-01-01;2017-01-01;;;Ablette;Toto;POINT(6.5 44.85);67111;Inconnu;geonature.fr;INVALID_EXISTING_PROOF_VALUE
+2017-01-01;2017-01-01;;;Ablette;Toto;POINT(6.5 44.85);67111;Inconnu;;Valide
+2017-01-01;2017-01-01;;;Ablette;Toto;POINT(6.5 44.85);67111;;geonature.fr;INVALID_EXISTING_PROOF_VALUE
+2017-01-01;2017-01-01;;;Ablette;Toto;POINT(6.5 44.85);67111;;;Valide

--- a/backend/gn_module_import/tests/files/empty_nomenclatures_file.csv
+++ b/backend/gn_module_import/tests/files/empty_nomenclatures_file.csv
@@ -1,0 +1,4 @@
+entity_source_pk_value;date_min;date_max;cd_nom;nom_cite;WKT;id_nomenclature_geo_object_nature;id_nomenclature_naturalness;id_nomenclature_life_stage
+1;2017-01-01;2017-01-01;60612;Lynx;POINT(6.5 44.85);Inventoriel;Sauvage;Adulte
+2;2017-01-01;2017-01-01;60612;Lynx;POINT(6.5 44.85);Inventoriel;;Adulte
+3;2017-01-01;2017-01-01;60612;Lynx;POINT(6.5 44.85);Inventoriel;Sauvage;

--- a/backend/gn_module_import/tests/files/nomenclatures_file.csv
+++ b/backend/gn_module_import/tests/files/nomenclatures_file.csv
@@ -9,6 +9,5 @@ date_min;nom_cite;observateurs;WKT;cd_nom;id_nomenclature_exist_proof;digital_pr
 2017-01-01;Ablette;Toto;POINT(6.5 44.85);67111;Oui;http://A.fr;;NSP;;;-
 2017-01-01;Ablette;Toto;POINT(6.5 44.85);67111;Oui;;B;NSP;;;-
 2017-01-01;Ablette;Toto;POINT(6.5 44.85);67111;Oui;http://A.fr;B;NSP;;;-
-2017-01-01;Ablette;Toto;POINT(6.5 44.85);67111;;;;;;;CONDITIONAL_MANDATORY_FIELD_ERROR
 2017-01-01;Ablette;Toto;POINT(6.5 44.85);67111;;;;NSP;Littérature;Petit ours brun;-
 2017-01-01;Ablette;Toto;POINT(6.5 44.85);67111;;;;NSP;Littérature;;CONDITIONAL_MANDATORY_FIELD_ERROR

--- a/backend/gn_module_import/tests/test_imports.py
+++ b/backend/gn_module_import/tests/test_imports.py
@@ -990,6 +990,11 @@ class TestImports:
             prepared_import,
             {
                 ("INVALID_URL_PROOF", "digital_proof", frozenset({2, 4, 5})),
+                (
+                    "INVALID_EXISTING_PROOF_VALUE",
+                    "id_nomenclature_exist_proof",
+                    frozenset({8, 9, 11, 13, 15}),
+                ),
             },
         )
 


### PR DESCRIPTION
- FILL_MISSING_NOMENCLATURE_WITH_DEFAULT_VALUE default to True
- Unmapped nomenclated fields always use default nomenclature
- For mapped nomenclated fields with empty value:
  - use value specified in content mapping if any
  - else, if FILL_… is True, use default nomenclature
  - else report an invalid nomenclature error