### PR TITLE
fix(import: checks) Improve check_altitudes and check_depths

### DIFF
--- a/backend/gn_module_import/checks/sql/__init__.py
+++ b/backend/gn_module_import/checks/sql/__init__.py
@@ -291,6 +291,12 @@ def set_altitudes(imprt, fields):
             }
         )
     )
+    fields.update(
+        {
+            "altitude_min": BibFields.query.filter_by(name_field="altitude_min").one(),
+            "altitude_max": BibFields.query.filter_by(name_field="altitude_max").one(),
+        }
+    )
     db.session.execute(stmt)
 
 
@@ -447,30 +453,35 @@ def check_dates(imprt, fields):
 
 
 def check_altitudes(imprt, fields):
-    if "altitude_min" not in fields or "altitude_max" not in fields:
-        return
-    alti_min_field = fields["altitude_min"]
-    alti_max_field = fields["altitude_max"]
-    alti_min_synthese_field = getattr(ImportSyntheseData, alti_min_field.synthese_field)
-    alti_max_synthese_field = getattr(ImportSyntheseData, alti_max_field.synthese_field)
-    report_erroneous_rows(
-        imprt,
-        error_type="ALTI_MIN_SUP_ALTI_MAX",
-        error_column=alti_min_field.name_field,
-        whereclause=(alti_min_synthese_field > alti_max_synthese_field),
-    )
-    report_erroneous_rows(
-        imprt,
-        error_type="INVALID_INTEGER",
-        error_column=alti_min_field.name_field,
-        whereclause=(alti_min_synthese_field < 0),
-    )
-    report_erroneous_rows(
-        imprt,
-        error_type="INVALID_INTEGER",
-        error_column=alti_max_field.name_field,
-        whereclause=(alti_max_synthese_field < 0),
-    )
+    if "altitude_min" in fields:
+        alti_min_field = fields["altitude_min"]
+        alti_min_name_field = alti_min_field.name_field
+        alti_min_synthese_field = getattr(ImportSyntheseData, alti_min_field.synthese_field)
+        report_erroneous_rows(
+            imprt,
+            error_type="INVALID_INTEGER",
+            error_column=alti_min_name_field,
+            whereclause=(alti_min_synthese_field < 0),
+        )
+
+    if "altitude_max" in fields:
+        alti_max_field = fields["altitude_max"]
+        alti_max_name_field = alti_max_field.name_field
+        alti_max_synthese_field = getattr(ImportSyntheseData, alti_max_field.synthese_field)
+        report_erroneous_rows(
+            imprt,
+            error_type="INVALID_INTEGER",
+            error_column=alti_max_name_field,
+            whereclause=(alti_max_synthese_field < 0),
+        )
+
+    if "altitude_min" in fields and "altitude_max" in fields:
+        report_erroneous_rows(
+            imprt,
+            error_type="ALTI_MIN_SUP_ALTI_MAX",
+            error_column=alti_min_name_field,
+            whereclause=(alti_min_synthese_field > alti_max_synthese_field),
+        )
 
 
 def check_depths(imprt, fields):
@@ -480,6 +491,7 @@ def check_depths(imprt, fields):
     depth_max_field = fields["depth_max"]
     depth_min_synthese_field = getattr(ImportSyntheseData, depth_min_field.synthese_field)
     depth_max_synthese_field = getattr(ImportSyntheseData, depth_max_field.synthese_field)
+
     report_erroneous_rows(
         imprt,
         error_type="DEPTH_MIN_SUP_ALTI_MAX",  # Yes, there is a typo in db...

--- a/backend/gn_module_import/checks/sql/__init__.py
+++ b/backend/gn_module_import/checks/sql/__init__.py
@@ -485,31 +485,35 @@ def check_altitudes(imprt, fields):
 
 
 def check_depths(imprt, fields):
-    if "depth_min" not in fields or "depth_max" not in fields:
-        return
-    depth_min_field = fields["depth_min"]
-    depth_max_field = fields["depth_max"]
-    depth_min_synthese_field = getattr(ImportSyntheseData, depth_min_field.synthese_field)
-    depth_max_synthese_field = getattr(ImportSyntheseData, depth_max_field.synthese_field)
+    if "depth_min" in fields:
+        depth_min_field = fields["depth_min"]
+        depth_min_name_field = depth_min_field.name_field
+        depth_min_synthese_field = getattr(ImportSyntheseData, depth_min_field.synthese_field)
+        report_erroneous_rows(
+            imprt,
+            error_type="INVALID_INTEGER",
+            error_column=depth_min_name_field,
+            whereclause=(depth_min_synthese_field < 0),
+        )
 
-    report_erroneous_rows(
-        imprt,
-        error_type="DEPTH_MIN_SUP_ALTI_MAX",  # Yes, there is a typo in db...
-        error_column=depth_min_field.name_field,
-        whereclause=(depth_min_synthese_field > depth_max_synthese_field),
-    )
-    report_erroneous_rows(
-        imprt,
-        error_type="INVALID_INTEGER",
-        error_column=depth_min_field.name_field,
-        whereclause=(depth_min_synthese_field < 0),
-    )
-    report_erroneous_rows(
-        imprt,
-        error_type="INVALID_INTEGER",
-        error_column=depth_max_field.name_field,
-        whereclause=(depth_max_synthese_field < 0),
-    )
+    if "depth_max" in fields:
+        depth_max_field = fields["depth_max"]
+        depth_max_name_field = depth_max_field.name_field
+        depth_max_synthese_field = getattr(ImportSyntheseData, depth_max_field.synthese_field)
+        report_erroneous_rows(
+            imprt,
+            error_type="INVALID_INTEGER",
+            error_column=depth_max_name_field,
+            whereclause=(depth_max_synthese_field < 0),
+        )
+
+    if "depth_min" in fields and "depth_max" in fields:
+        report_erroneous_rows(
+            imprt,
+            error_type="DEPTH_MIN_SUP_ALTI_MAX",  # Yes, there is a typo in db... Should be "DEPTH_MIN_SUP_DEPTH_MAX"
+            error_column=depth_min_name_field,
+            whereclause=(depth_min_synthese_field > depth_max_synthese_field),
+        )
 
 
 def check_digital_proof_urls(imprt, fields):


### PR DESCRIPTION
----
`check_altitudes`

Still perform check_altitudes when altitudes are generated : update fields in `set_altitudes`.

Still perform "INVALID_INTEGER" error checks for "altitude_min" when "altitude_max" not in fields, and for "altitude_max" when "altitude_min" not in fields.

----
`check_depths`

Still perform "INVALID_INTEGER" error checks for "depth_min" when "depth_max" not in fields, and for "depth_max" when "depth_min" not in fields.
