### PR TITLE
Bump pyproj version for Debian 12 compatibility

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,6 @@
 pandas<1.4  # panda 1.4 requires sqlalchemy>=1.4
 pyproj<3;python_version<"3.10"  # v3 require PROJ 7.2.0 but Debian 10 provide PROJ 5.2.0
+pyproj;python_version>="3.10"
 chardet
 jsonschema
 utils-flask-sqlalchemy>=0.3.0,<1.0.0

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 pandas<1.4  # panda 1.4 requires sqlalchemy>=1.4
-pyproj<3  # v3 require PROJ 7.2.0 but Debian 10 provide PROJ 5.2.0
+pyproj<3;python_version<"3.10"  # v3 require PROJ 7.2.0 but Debian 10 provide PROJ 5.2.0
 chardet
 jsonschema
 utils-flask-sqlalchemy>=0.3.0,<1.0.0


### PR DESCRIPTION
Keep pyproj<3 for python <3.10 for Debian 10 compatibility