### PR TITLE
fix(import_list): wrong link color

### DIFF
--- a/frontend/app/components/import_list/import-list.component.html
+++ b/frontend/app/components/import_list/import-list.component.html
@@ -53,7 +53,7 @@
                                     {{row.date_create_import |date:'dd-MM-yyyy'}}
                                 </ng-container>
                                 <ng-container *ngSwitchCase="'full_file_name'">
-                                    <a [routerLink]="" (click)="downloadSourceFile(row)">{{row[col.prop]}}</a>
+                                    <a href="javascript:void(0)" (click)="downloadSourceFile(row)">{{row[col.prop]}}</a>
                                 </ng-container>
                                 <ng-container *ngSwitchDefault>
                                     {{row[col.prop]}}


### PR DESCRIPTION
 the color was wrong because [routerlink]="" doesn't work anymore, i added href="javascript:void(0)"

### To test: 

- Go to import
- Have some imports in the list
- Check that the link to download files have the right css
- Check that you can download the files 