### PR TITLE
fix(import_report): display "Données importées" panel only when done

### DIFF
--- a/frontend/app/components/import_report/import_report.component.html
+++ b/frontend/app/components/import_report/import_report.component.html
@@ -259,7 +259,7 @@
       </div>
       </div>
     </mat-expansion-panel>
-    <mat-expansion-panel class="card content row" [expanded]="true" *ngIf="validBbox || doughnutChartData.length > 0">
+    <mat-expansion-panel class="card content row" [expanded]="true" *ngIf="importStatus == 'TERMINE'">
       <mat-expansion-panel-header class="card-header">
         <div class="d-flex justify-content-start">
           <mat-panel-title>


### PR DESCRIPTION
Display panel "Données importées" only when import is "done", not when "in progress" or "in error".

## How to test 

1. Create an import (which you know would work without errors) and stop before the end, to let in "in progress" : you may stop at step 2, right after clicking "Suivant" in step 1
2. Go to see the report of this import, and observe that it is still in progress ("EN COURS" appearing on the top right), and that there are only three panels ; "Description de l'import", "Correspondances" and "Données invalides" ; but no panel "Données importées" visible **(fixed by the present commit)**
3. Finalize the import : go until through all steps, until step 5, and launch the check (click on "Lancer la vérification") while asserting that a celery worker is running locally / then, after checks are done, confirm import of observations (click on "Importer vos N observations valides".
4. Go to the report, and observe that the import is done ("TERMINE" on the top right) and that a 4th panel "Données importées" is now visible.