### PR TITLE
fix(config): adding a check during the synthese import

### DIFF
--- a/backend/gn_module_import/utils.py
+++ b/backend/gn_module_import/utils.py
@@ -223,7 +223,9 @@ def import_data_to_synthese(imprt):
         "the_geom_point",
         "id_area_attachment",
     }
-    if imprt.fieldmapping.get("unique_id_sinp_generate", False):
+    if imprt.fieldmapping.get(
+        "unique_id_sinp_generate", current_app.config["IMPORT"]["DEFAULT_GENERATE_MISSING_UUID"]
+    ):
         generated_fields |= {"unique_id_sinp"}
     if imprt.fieldmapping.get("altitudes_generate", False):
         generated_fields |= {"altitude_min", "altitude_max"}


### PR DESCRIPTION
Si la checkbox de génération des uuid manquants était caché, on checkais le param DEFAULT_GENERATE_MISSING_UUID, mais lors du transfert vers la synthese on ne checkais pas