### PR TITLE
feat(perf): improving perf by passing the outside geom check from panda to SQL

### DIFF
--- a/backend/gn_module_import/checks/dataframe/geography.py
+++ b/backend/gn_module_import/checks/dataframe/geography.py
@@ -146,23 +146,6 @@ def check_geography(
                 }
             )
 
-        if id_area is not None:
-            inside = df[mask & df["_geom"].notnull()]["_geom"].apply(
-                partial(check_geometry_inside_l_areas, id_area=id_area, geom_srid=file_srid)
-            )
-
-            is_outside = df[mask & ~inside]
-
-            if len(is_outside):
-                df.loc[mask & ~bound, "_geom"] = None
-                errors.append(
-                    {
-                        "error_code": "GEOMETRY_OUTSIDE",
-                        "column": column,
-                        "invalid_rows": is_outside,
-                    }
-                )
-
     if "codecommune" in fields:
         codecommune_field = fields["codecommune"].source_field
         codecommune_mask = df[codecommune_field].notnull()

--- a/backend/gn_module_import/tasks.py
+++ b/backend/gn_module_import/tasks.py
@@ -34,6 +34,7 @@ from gn_module_import.checks.sql import (
     check_depths,
     check_digital_proof_urls,
     check_geography_outside,
+    check_is_valid_geography,
 )
 
 from geonature.core.notifications.utils import dispatch_notifications
@@ -104,6 +105,7 @@ def do_import_checks(self, import_id):
         check_digital_proof_urls,
         check_mandatory_fields,
         check_geography_outside,
+        check_is_valid_geography,
     ]
     with start_sentry_child(op="check.sql", description="run all checks"):
         for i, check in enumerate(sql_checks):

--- a/backend/gn_module_import/tasks.py
+++ b/backend/gn_module_import/tasks.py
@@ -33,6 +33,7 @@ from gn_module_import.checks.sql import (
     check_altitudes,
     check_depths,
     check_digital_proof_urls,
+    check_geography_outside,
 )
 
 from geonature.core.notifications.utils import dispatch_notifications
@@ -102,6 +103,7 @@ def do_import_checks(self, import_id):
         check_depths,
         check_digital_proof_urls,
         check_mandatory_fields,
+        check_geography_outside,
     ]
     with start_sentry_child(op="check.sql", description="run all checks"):
         for i, check in enumerate(sql_checks):

--- a/backend/gn_module_import/tests/files/geom_file.csv
+++ b/backend/gn_module_import/tests/files/geom_file.csv
@@ -13,3 +13,4 @@ date_min;cd_nom;nom_cite;observateurs;WKT;latitude;longitude;codecommune;codedep
 2017-01-01;67111;Ablette;Toto;;44.85;6.5;;;;Valide (X/Y)
 2017-01-01;67111;Ablette;Toto;POINT(6.5 44.85);44.85;6.5;;;;MULTIPLE_ATTACHMENT_TYPE_CODE
 2017-01-01;67111;Ablette;Toto;;;;;;;NO-GEOM
+2017-01-01;67111;Ablette;Toto;POLYGON((0 0, 1 1, 1 2, 1 1, 0 0));;;;;;INVALID_GEOMETRY

--- a/backend/gn_module_import/tests/test_dataframe_checks.py
+++ b/backend/gn_module_import/tests/test_dataframe_checks.py
@@ -190,37 +190,6 @@ class TestChecks:
             ],
         )
 
-    def test_check_geography_outside(self, imprt, sample_area):
-        fields = get_fields(
-            [
-                "WKT",
-                "longitude",
-                "latitude",
-                "codecommune",
-                "codemaille",
-                "codedepartement",
-            ]
-        )
-        df = pd.DataFrame(
-            [
-                ["Point(600000 7000000)", None, None, None, None, None],
-                [None, "600000", "7000000", None, None, None],
-            ],
-            columns=[field.source_field for field in fields.values()],
-        )
-
-        errors = check_geography(df, fields, file_srid=imprt.srid, id_area=sample_area.id_area)
-
-        assert_errors(
-            errors,
-            expected=[
-                Error(error_code="GEOMETRY_OUTSIDE", column="WKT", invalid_rows=frozenset([0])),
-                Error(
-                    error_code="GEOMETRY_OUTSIDE", column="longitude", invalid_rows=frozenset([1])
-                ),
-            ],
-        )
-
     def test_check_types(self, imprt):
         uuid = "82ff094c-c3b3-11eb-9804-bfdc95e73f38"
         fields = get_fields(

--- a/backend/gn_module_import/tests/test_imports.py
+++ b/backend/gn_module_import/tests/test_imports.py
@@ -929,9 +929,10 @@ class TestImports:
                     "Champs géométriques",
                     frozenset([10, 13]),
                 ),
-                ("GEOMETRY_OUTSIDE", "WKT", frozenset([8, 11])),
+                ("GEOMETRY_OUTSIDE", "WKT", frozenset([8, 11, 15])),
                 ("GEOMETRY_OUTSIDE", "longitude", frozenset([9, 12])),
                 ("NO-GEOM", "Champs géométriques", frozenset([14])),
+                ("INVALID_GEOMETRY", "WKT", frozenset([15])),
             },
         )
 

--- a/backend/gn_module_import/tests/test_imports.py
+++ b/backend/gn_module_import/tests/test_imports.py
@@ -28,6 +28,7 @@ from geonature.tests.fixtures import synthese_data, celery_eager
 from pypnusershub.db.models import User, Organisme
 from pypnnomenclature.models import TNomenclatures, BibNomenclaturesTypes
 from ref_geo.tests.test_ref_geo import has_french_dem
+from ref_geo.models import LAreas
 
 from gn_module_import.models import (
     TImports,
@@ -101,6 +102,11 @@ def assert_import_errors(imprt, expected_errors):
         assert erroneous_rows == expected_erroneous_rows
 
 
+@pytest.fixture()
+def sample_area():
+    return LAreas.query.filter(LAreas.area_name == "Bouches-du-Rhône").one()
+
+
 @pytest.fixture(scope="function")
 def imports(users):
     def create_import(authors=[]):
@@ -122,6 +128,11 @@ def no_default_nomenclatures(monkeypatch):
     monkeypatch.setitem(
         current_app.config["IMPORT"], "FILL_MISSING_NOMENCLATURE_WITH_DEFAULT_VALUE", False
     )
+
+
+@pytest.fixture()
+def area_restriction(monkeypatch, sample_area):
+    monkeypatch.setitem(current_app.config["IMPORT"], "ID_AREA_RESTRICTION", sample_area.id_area)
 
 
 @pytest.fixture()
@@ -905,7 +916,7 @@ class TestImports:
         assert r.status_code == 200, r.data
 
     @pytest.mark.parametrize("import_file_name", ["geom_file.csv"])
-    def test_import_geometry_file(self, prepared_import):
+    def test_import_geometry_file(self, area_restriction, prepared_import):
         assert_import_errors(
             prepared_import,
             {
@@ -918,6 +929,8 @@ class TestImports:
                     "Champs géométriques",
                     frozenset([10, 13]),
                 ),
+                ("GEOMETRY_OUTSIDE", "WKT", frozenset([8, 11])),
+                ("GEOMETRY_OUTSIDE", "longitude", frozenset([9, 12])),
                 ("NO-GEOM", "Champs géométriques", frozenset([14])),
             },
         )


### PR DESCRIPTION
https://github.com/PnX-SI/gn_module_import/issues/423

### Améliorations

Grace a des tests réalisés, j'ai pu déterminer que le check en sql vas presque 10 fois plus vite.

| Nombre d'observations  |  SQL |  Panda |
| :--------------- |:---------------:| -----:|
| 100  | 0.016 | 0.16 |
| 1000  | 0.11 |  1.3  |
| 10000  | 1.3 | 13.7 |
| 100000 | 14.27 | 2:32.32 |

J'ai également réalisé des tests en local pour voir si la charge possible sur un import, j'ai pu faire un import de 300000 observations, mais pas plus et cela a pris beaucoup de temps.

J'ai également changé les tests.