### PR TITLE
feat(front): add group3_inpn to chart in report

### DIFF
--- a/frontend/app/components/import_report/import_report.component.ts
+++ b/frontend/app/components/import_report/import_report.component.ts
@@ -40,6 +40,7 @@ export class ImportReportComponent implements OnInit {
     "tribu",
     "group1_inpn",
     "group2_inpn",
+    "group3_inpn",
   ];
   public importData: Import | null;
   public expansionPanelHeight: string = "60px";


### PR DESCRIPTION
Dans le cadre d'une prestation pour l'Agence Régionale de la Biodiversité, ajout du groupe3 Inpn dans le graphique situé dans le rapport d'import.

**Attention** : Cette PR dépend de https://github.com/PnX-SI/TaxHub/pull/409 car elle ajoute la colonne `group3_inpn` au model `Taxref`